### PR TITLE
Fix issue caused by draft releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 bower_components
 build
+.packages
 packages
 web/bower_components
 web/packages

--- a/lib/src/actions.dart
+++ b/lib/src/actions.dart
@@ -1,7 +1,5 @@
 library gridhub.actions;
 
-import 'package:flux/flux.dart';
-
 import 'package:gridhub/src/actions/global_state_actions.dart';
 import 'package:gridhub/src/actions/repo_actions.dart';
 

--- a/lib/src/components/tags_pane.dart
+++ b/lib/src/components/tags_pane.dart
@@ -36,11 +36,16 @@ class _TagsPane extends react.Component {
       if (release != null) {
         var header = react.a({'href': release['html_url'], 'target': repo.name}, release['name']);
 
-        String relativeDate = getRelativeDate(DateTime.parse(release['published_at']));
+        String relativeDate;
+        if (release['published_at'] != null) {
+          relativeDate = getRelativeDate(DateTime.parse(release['published_at']));
+        } else {
+          relativeDate = 'draft';
+        }
         var body = react.span({},
         react.div({}, [
           AuthorLink({'author': release['author'], 'includePicture': true, 'key': 'author-link'}),
-          react.span({'className': 'text-muted', 'key': 'text'}, ' released this ${relativeDate}')
+          react.span({'className': 'text-muted', 'key': 'text'}, ' published this ${relativeDate}')
         ])
 //                    react.div({}, [
 //                        react.span({}, release['body'])

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -41,3 +41,5 @@ packages:
       url: "git@github.com:Workiva/web-skin-react.git"
     source: git
     version: "2.1.2"
+sdks:
+  dart: ">=1.3.0-dev.4.1 <2.0.0"


### PR DESCRIPTION
GridHub wasn't working for me anymore.

Turned out to be a null exception parsing the `published_at` date for draft (unpublished) releases.